### PR TITLE
Replace Element with HTMLElement in createElement and vApp

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -30,7 +30,7 @@ const router = createRouter(routes);
 
 
 
-let vApp: Element;
+let vApp: HTMLElement;
 
 // the vApp for the todo list
 if (route_path == '/') {
@@ -55,7 +55,7 @@ if (route_path == '/') {
     });
 }
 
-export function getVApp(): Element {
+export function getVApp(): HTMLElement {
     return vApp;
 }
 

--- a/src/core/createElement.ts
+++ b/src/core/createElement.ts
@@ -1,4 +1,4 @@
-const createElement = (tagName: string, { attrs = {}, events = {}, children = [] }: { attrs?: Record<string, string>; events?: Record<string, (event: Event) => void>; children?: (string | Element)[] }): Element => {
+const createElement = (tagName: string, { attrs = {}, events = {}, children = [] }: { attrs?: Record<string, string>; events?: Record<string, (event: Event) => void>; children?: (string | HTMLElement)[] }): HTMLElement => {
     // Create a new HTML element of the specified tagName
     const element = document.createElement(tagName);
 

--- a/src/core/mount.ts
+++ b/src/core/mount.ts
@@ -1,5 +1,5 @@
 // The mount function is used to replace a target HTML element with a new node in the DOM
-const mount = ($target: HTMLElement, $node: Element) => {
+const mount = ($target: HTMLElement, $node: HTMLElement) => {
     // Replace the $target element with the $node element in the DOM
     $target.replaceWith($node);
     return $node;

--- a/src/core/vdom.ts
+++ b/src/core/vdom.ts
@@ -4,7 +4,7 @@ import { vApp } from "../../app/main";
 // singleton class to manage the vApp
 class VAppManager {
     private static instance: VAppManager;
-    private vApp: Element | null = null;
+    private vApp: HTMLElement | null = null;
 
     private constructor() {}
 
@@ -15,17 +15,17 @@ class VAppManager {
         return VAppManager.instance;
     }
 
-    public setVApp(newVApp: Element): void {
+    public setVApp(newVApp: HTMLElement): void {
         this.vApp = newVApp;
     }
 
-    public getVApp(): Element | null {
+    public getVApp(): HTMLElement | null {
         return this.vApp;
     }
 }
 
 // export the vApp to use it in other files
-let vAppElements: Element | undefined;
+let vAppElements: HTMLElement | undefined;
 
 // if the vApp is undefined, then create a div with 404 - Page Not Found
 const vAppManager = VAppManager.getInstance();


### PR DESCRIPTION
The `createElement` function currently uses `Element` as the return type. However, `Element` does not have a `style` attribute, which limits the ability to set styles directly on the created element. To fix this, the return type should be updated to `HTMLElement`, which includes the `style` attribute and provides the necessary functionality for styling elements directly.

```typescript
const createElement = (
  tagName: string,
  { attrs = {}, events = {}, children = [] }: {
    attrs?: Record<string, string>;
    events?: Record<string, (event: Event) => void>;
    children?: (string | Element)[];
  }
): Element => {
```

### Proposed Change:
Update the return type from `Element` to `HTMLElement` to enable usage of the `style` attribute.

```typescript
const createElement = (
  tagName: string,
  { attrs = {}, events = {}, children = [] }: {
    attrs?: Record<string, string>;
    events?: Record<string, (event: Event) => void>;
    children?: (string | HTMLElement)[];
  }
): HTMLElement => {
```

Apply the same to VApp